### PR TITLE
Error listeners should only run once

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ Rabbit.prototype.connect = function (tries) {
     });
 
     // If disconnect, we want to try to connect again
-    self.eventer.on('error', function (e) {
+    self.eventer.once('error', function (e) {
       setTimeout(function () {
         self.connect.call(self, tries);
       }, self.initial_timeout);
@@ -98,8 +98,8 @@ Rabbit.prototype.go = function (onConnect) {
     });
   });
 
-  self.eventer.on('error', function (e) {
-    self.eventer.on('connected', function () {
+  self.eventer.once('error', function (e) {
+    self.eventer.once('connected', function () {
       self.go(onConnect);
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,20 +90,13 @@ describe('Rabbit wrapper', function () {
 
     it('Should not leave residual error-listeners on error', function (done) {
       var rabbiter = new rabbit(config);
-      var spy = sinon.spy();
 
-      rabbiter.go(function (ch) {
-        spy(ch);
-        var clock = sinon.useFakeTimers();
-        clock.tick(1100);
-        expect(spy.calledTwice).to.be.ok;
-        clock.restore();
-        done();
-      });
+      rabbiter.go(function () {});
 
       expect(rabbiter.eventer.listeners('error').length).to.equal(1);
       rabbiter.eventer.emit('error', 'Error');
       expect(rabbiter.eventer.listeners('error').length).to.equal(0);
+      done();
     });
 
     it('Should be able to send, receive and ack a message', function (done) {


### PR DESCRIPTION
From `on` to `once`.
